### PR TITLE
Revise depletion to use MPI OpenDeplete

### DIFF
--- a/2x2-periodic/build-depleted.py
+++ b/2x2-periodic/build-depleted.py
@@ -12,7 +12,7 @@ radius = 0.39218
 height = 5.
 
 # Count the number of instances for each cell and material
-num_instances = opendeplete.lomem_num_instances(openmc_geometry)
+openmc_geometry.determine_paths(instances_only=True)
 
 # Extract all cells filled by a fuel material
 fuel_cells = openmc_geometry.get_cells_by_name(
@@ -20,15 +20,11 @@ fuel_cells = openmc_geometry.get_cells_by_name(
 
 # Assign distribmats for each material
 for cell in fuel_cells:
-    old_fill = cell.fill.clone()
+    cell.fill.volume = np.pi * radius**2 * height
+    cell.fill.depletable = True
+    cell.fill.temperature = 300.0
 
-    n = num_instances[cell.id]
-    cell.fill = [old_fill.clone() for i in range(n)]
-
-    for i in range(n):
-        cell.fill[i].volume = np.pi * radius**2 * height
-        cell.fill[i].depletable = True
-        cell.fill[i].temperature = 300.0
+    cell.fill = [cell.fill.clone() for i in range(cell.num_instances)]
 
 # Set temperature for all cells
 cells = openmc_geometry.get_all_cells()

--- a/2x2-reflector/build-depleted.py
+++ b/2x2-reflector/build-depleted.py
@@ -12,7 +12,7 @@ radius = 0.39218
 height = 5.
 
 # Count the number of instances for each cell and material
-num_instances = opendeplete.lomem_num_instances(openmc_geometry)
+openmc_geometry.determine_paths(instances_only=True)
 
 # Extract all cells filled by a fuel material
 fuel_cells = openmc_geometry.get_cells_by_name(
@@ -20,15 +20,11 @@ fuel_cells = openmc_geometry.get_cells_by_name(
 
 # Assign distribmats for each material
 for cell in fuel_cells:
-    old_fill = cell.fill.clone()
+    cell.fill.volume = np.pi * radius**2 * height
+    cell.fill.depletable = True
+    cell.fill.temperature = 300.0
 
-    n = num_instances[cell.id]
-    cell.fill = [old_fill.clone() for i in range(n)]
-
-    for i in range(n):
-        cell.fill[i].volume = np.pi * radius**2 * height
-        cell.fill[i].depletable = True
-        cell.fill[i].temperature = 300.0
+    cell.fill = [cell.fill.clone() for i in range(cell.num_instances)]
 
 # Set temperature for all cells
 cells = openmc_geometry.get_all_cells()

--- a/assembly/build-depleted.py
+++ b/assembly/build-depleted.py
@@ -12,7 +12,7 @@ radius = 0.39218
 height = 5.
 
 # Count the number of instances for each cell and material
-num_instances = opendeplete.lomem_num_instances(openmc_geometry)
+openmc_geometry.determine_paths(instances_only=True)
 
 # Extract all cells filled by a fuel material
 fuel_cells = openmc_geometry.get_cells_by_name(
@@ -20,15 +20,11 @@ fuel_cells = openmc_geometry.get_cells_by_name(
 
 # Assign distribmats for each material
 for cell in fuel_cells:
-    old_fill = cell.fill.clone()
+    cell.fill.volume = np.pi * radius**2 * height
+    cell.fill.depletable = True
+    cell.fill.temperature = 300.0
 
-    n = num_instances[cell.id]
-    cell.fill = [old_fill.clone() for i in range(n)]
-
-    for i in range(n):
-        cell.fill[i].volume = np.pi * radius**2 * height
-        cell.fill[i].depletable = True
-        cell.fill[i].temperature = 300.0
+    cell.fill = [cell.fill.clone() for i in range(cell.num_instances)]
 
 # Set temperature for all cells
 cells = openmc_geometry.get_all_cells()

--- a/pin-cell/build-depleted.py
+++ b/pin-cell/build-depleted.py
@@ -12,7 +12,7 @@ radius = 0.39218
 height = 5.
 
 # Count the number of instances for each cell and material
-num_instances = opendeplete.lomem_num_instances(openmc_geometry)
+openmc_geometry.determine_paths(instances_only=True)
 
 # Extract all cells filled by a fuel material
 fuel_cells = openmc_geometry.get_cells_by_name(
@@ -20,15 +20,11 @@ fuel_cells = openmc_geometry.get_cells_by_name(
 
 # Assign distribmats for each material
 for cell in fuel_cells:
-    old_fill = cell.fill.clone()
+    cell.fill.volume = np.pi * radius**2 * height
+    cell.fill.depletable = True
+    cell.fill.temperature = 300.0
 
-    n = num_instances[cell.id]
-    cell.fill = [old_fill.clone() for i in range(n)]
-
-    for i in range(n):
-        cell.fill[i].volume = np.pi * radius**2 * height
-        cell.fill[i].depletable = True
-        cell.fill[i].temperature = 300.0
+    cell.fill = [cell.fill.clone() for i in range(cell.num_instances)]
 
 # Set temperature for all cells
 cells = openmc_geometry.get_all_cells()

--- a/smr/build-depleted.py
+++ b/smr/build-depleted.py
@@ -13,7 +13,7 @@ radius = 0.39218
 height = 200.
 
 # Count the number of instances for each cell and material
-num_instances = opendeplete.lomem_num_instances(geometry)
+geometry.determine_paths(instances_only=True)
 
 # Extract all cells filled by a fuel material
 fuel_cells = geometry.get_cells_by_name(
@@ -37,15 +37,11 @@ fuel_cells.extend(geometry.get_cells_by_name(
 
 # Assign distribmats for each material
 for cell in fuel_cells:
-    old_fill = cell.fill.clone()
+    cell.fill.volume = np.pi * radius**2 * height
+    cell.fill.depletable = True
+    cell.fill.temperature = 300.0
 
-    n = num_instances[cell.id]
-    cell.fill = [old_fill.clone() for i in range(n)]
-
-    for i in range(n):
-        cell.fill[i].volume = np.pi * radius**2 * height
-        cell.fill[i].depletable = True
-        cell.fill[i].temperature = 300.0
+    cell.fill = [cell.fill.clone() for i in range(cell.num_instances)]
 
 # Create dt vector for 1 month with 5 day timesteps
 dt1 = 5*24*60*60  # 5 days


### PR DESCRIPTION
This modifies the depletion codes to use the MPI branch of OpenDeplete.  This new MPI mode allows for domain decomposition and eliminates a lot of accidental data duplication the previous parallel approaches took.  As such, it should use around an order of magnitude less RAM.  

On Falcon, the SMR simulation used around 100 GB of RAM total split evenly on 4 nodes instead of running out as it had prior.  In theory, further improvements can be had at the cost of abandoning more of the Python API.  There's a lower limit with how OpenMC is configured now of 32 GB total.

I didn't run with MCNP data, as I didn't have it on hand, but that did allow me to find a bug.  Prior versions of the 2x2 periodic and possibly others had some cells set at 0K, which then ran at the MCNP6 0.1K.  I have fixed this such that all cells are constant 300K.  Additionally, the pincell Shannon entropy grid is too small, but I am unsure what it is supposed to be.

Finally, I did have concerns on the SMR.  When I ran it with admittedly 1/100th the number of neutrons so that I could finish it in a reasonable period of time, the vast majority of tallies were zero.  I would keep an eye out on this as even 100 neutrons/cell is probably undersampled.

I'm not yet ready to merge the MPI branch, as I keep getting occasional ideas for improvement, but I thought I would preliminarily PR this for others' inspection, as almost all the changes I'm making in the MPI branch right now are to improve this.