### PR TITLE
Small cleanup

### DIFF
--- a/smr/build-assembly-long.py
+++ b/smr/build-assembly-long.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import argparse
-import copy
 from math import pi, isclose
 from pathlib import Path
 
@@ -9,10 +8,9 @@ import numpy as np
 from tqdm import tqdm
 import openmc
 
-from smr.materials import materials, mats
+from smr.materials import materials, clone
 from smr.surfaces import surfs, lattice_pitch, pin_pitch, bottom_fuel_stack, \
-    top_active_core, pellet_OR, clad_OR, clad_IR, guide_tube_IR, guide_tube_OR, \
-    active_fuel_length
+    top_active_core, pellet_OR, active_fuel_length
 from smr.pins import pin_universes, make_stack
 
 
@@ -100,13 +98,6 @@ for halfspace in surfs['lat grid box inner']:
 
 # Define geometry with a single assembly
 geometry = openmc.Geometry(root_universe)
-
-
-def clone(material):
-    """Perform copy of material but share nuclide densities"""
-    shared_mat = copy.copy(material)
-    shared_mat.id = None
-    return shared_mat
 
 h = active_fuel_length / args.axial
 

--- a/smr/build-assembly-short.py
+++ b/smr/build-assembly-short.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import argparse
-import copy
 from math import pi, isclose
 from pathlib import Path
 
@@ -9,7 +8,7 @@ import numpy as np
 from tqdm import tqdm
 import openmc
 
-from smr.materials import materials, mats
+from smr.materials import materials, clone
 from smr.surfaces import surfs, lattice_pitch, pin_pitch, bottom_fuel_stack, \
     top_active_core, pellet_OR, clad_OR, clad_IR, guide_tube_IR, guide_tube_OR
 from smr.pins import pin_universes
@@ -84,14 +83,6 @@ for halfspace in surfs['lat grid box inner']:
 
 # Define geometry with a single assembly
 geometry = openmc.Geometry(root_universe)
-
-
-def clone(material):
-    """Perform copy of material but share nuclide densities"""
-    shared_mat = copy.copy(material)
-    shared_mat.id = None
-    return shared_mat
-
 
 #### "Differentiate" the geometry if using distribmats
 h = 10.0*pin_pitch / args.axial

--- a/smr/build-assembly.py
+++ b/smr/build-assembly.py
@@ -1,14 +1,13 @@
 #!/usr/bin/env python3
 
 import argparse
-import copy
 from pathlib import Path
 
 import numpy as np
 from tqdm import tqdm
 
 import openmc
-from smr.materials import materials
+from smr.materials import materials, clone
 from smr.surfaces import surfs, lattice_pitch, bottom_fuel_stack, top_active_core, pellet_OR
 from smr.assemblies import assembly_universes
 from smr.plots import assembly_plots
@@ -57,14 +56,6 @@ main_cell = openmc.Cell(
 )
 root_univ = openmc.Universe(cells=[main_cell])
 geometry = openmc.Geometry(root_univ)
-
-
-def clone(material):
-    """Perform copy of material but share nuclide densities"""
-    shared_mat = copy.copy(material)
-    shared_mat.id = None
-    return shared_mat
-
 
 #### "Differentiate" the geometry if using distribmats
 if args.tallies == 'mat':

--- a/smr/build-core-fresh.py
+++ b/smr/build-core-fresh.py
@@ -9,18 +9,11 @@ import numpy as np
 import openmc
 from tqdm import tqdm
 
-from smr.materials import materials
+from smr.materials import materials, clone
 from smr.surfaces import lattice_pitch, bottom_fuel_stack, top_active_core, \
     pellet_OR, active_fuel_length
 from smr.core import core_geometry
 from smr import inlet_temperature
-
-
-def clone(material):
-    """Perform copy of material but share nuclide densities"""
-    shared_mat = copy.copy(material)
-    shared_mat.id = None
-    return shared_mat
 
 
 # Define command-line options

--- a/smr/milestones.md
+++ b/smr/milestones.md
@@ -1,0 +1,20 @@
+# Milestone Models
+
+- **AD-SE-08-61, Coupled Multiphysics Driver Implementation** --- This milestone
+  used the singlerod short/long problems. Generating the model was done with the
+  script `tests/singlerod/make_openmc_model.py` from the ENRICO repository
+  (there is a `--short` command line option to generate the short version)
+
+- **AD-SE-08-66, Coupled Assembly Analysis** --- This milestone used the
+  assembly short and long (v2) problems. Generating the model was done with
+  `smr/build-assembly-long.py -a 100 --clone` on the ecp-benchmarks repository
+  (git commit `631fefe`, after pull request #14). In these models, materials are
+  fully differentiated across each fuel ring/axial segment.
+
+- **AD-SE-08-73, Full core coupled-physics simulation** --- This milestone used
+  the core-short and core-long (90 layer) models. Generating the models was done
+  with `smr/build-core-short.py` and `smr/build-assembly-long.py -a 90` on the
+  ecp-benchmarks repository (git commit `c7b89db`, after pull request #16). In
+  these models, materials are not differentiated and no grid spacers are
+  present. The lattice pitch is modified to be exactly 17 times the pin pitch
+  (slightly different than NuScale specification).

--- a/smr/smr/materials.py
+++ b/smr/smr/materials.py
@@ -1,5 +1,7 @@
 """Instantiate the OpenMC Materials needed by the core model."""
 
+import copy
+
 import openmc
 from openmc.data import atomic_weight, atomic_mass, water_density
 
@@ -252,3 +254,10 @@ mats['UO2 3.1 depleted'] = mat
 # Construct a collection of Materials to export to XML
 
 materials = openmc.Materials(mats.values())
+
+
+def clone(material):
+    """Perform copy of material but share nuclide densities"""
+    shared_mat = copy.copy(material)
+    shared_mat.id = None
+    return shared_mat


### PR DESCRIPTION
This PR:

- Moves the `clone` function that is copied in a bunch of scripts to a single location (smr/surfaces.py)
- Adds a markdown file describing which scripts were used for which milestones